### PR TITLE
Backtick codeblock

### DIFF
--- a/covert/cli.py
+++ b/covert/cli.py
@@ -197,7 +197,7 @@ def main_enc(args):
     if outf is not realoutf:
       with realoutf:
         if realoutf.isatty():
-          stderr.write("\x1B[0;34m")
+          stderr.write("\x1B[1;30m```\x1B[0;34m\n")
           stderr.flush()
         try:
           data = util.armor_encode(data)
@@ -206,7 +206,7 @@ def main_enc(args):
         finally:
           try:
             if realoutf.isatty():
-              stderr.write(f"\x1B[0m")
+              stderr.write("\x1B[1;30m```\x1B[0m\n")
               stderr.flush()
           except Exception:
             pass


### PR DESCRIPTION
Switch to standard Base64 due to less problematic charset, and to make Covert armoring harder to fingerprint. Line lengths are also now randomized.

Armored blocks are, on console, printed between triple-backticks, which mark a codeblock on most messaging systems. The backticks are not part of the message and may be pasted or left out.
