### PR TITLE
Minor cleanup of CLI main

### DIFF
--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -4,7 +4,6 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from hashlib import sha512
-from sys import stderr
 
 from nacl.exceptions import CryptoError
 

--- a/covert/passphrase.py
+++ b/covert/passphrase.py
@@ -1,6 +1,6 @@
 import secrets
+import sys
 from contextlib import suppress
-from sys import argv
 
 import nacl.bindings as sodium
 from zxcvbn import zxcvbn
@@ -156,7 +156,7 @@ def ask(prompt, create=False):
 
 def pwhints(pwd: str):
   maxlen = 20  # zxcvbn gets slow with long passwords
-  z = zxcvbn(pwd[:maxlen], user_inputs=argv)
+  z = zxcvbn(pwd[:maxlen], user_inputs=sys.argv)
   fb = z["feedback"]
   warn = fb["warning"]
   sugg = fb["suggestions"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,3 +159,21 @@ def test_end_to_end_large_file(covert, tmp_path):
   cap = covert("-eaRo", "tests/keys/ssh_ed25519.pub", outfname, fname, exitcode=10)
   assert not cap.out
   assert "The data is too large for --armor." in cap.err
+
+
+def test_errors(covert):
+  cap = covert()
+  assert "Usage:" in cap.out
+  assert not cap.err
+
+  cap = covert('-eINvalid', '--help')
+  assert "Usage:" in cap.out
+  assert not cap.err
+
+  cap = covert('-eINvalid', exitcode=1)
+  assert not cap.out
+  assert "not an argument: covert enc -INvalid" in cap.err
+
+  cap = covert("-o", exitcode=1)
+  assert not cap.out
+  assert "Invalid or missing command" in cap.err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,8 @@
 import pytest
 import sys
+from covert.__main__ import argparse, main
 
 def test_argparser(capsys):
-  from covert.__main__ import argparse  # Import only *after* capsys wraps sys.stdout/stderr
-
   # Correct but complex arguments
   sys.argv = "covert enc --recipient recipient1 -r recipient2 -Arrp recipient3 recipient4".split()
   a = argparse()
@@ -41,24 +40,32 @@ def test_argparser(capsys):
   assert "Argument parameter missing: covert enc -Arrp …" in cap.err
 
 
-def test_end_to_end(capsys, tmp_path):
-  from covert.__main__ import main
-  import sys
+## End-to-End testing: Running Covert as if it was ran from command line
+
+# A fixture to run covert more easily, checks exitcode and returns its output
+@pytest.fixture
+def covert(capsys):
+  def run_main(*args, exitcode=0):
+    if args and args[0] == "covert":
+      raise ValueError("Only arguments please, no 'covert' in the beginning")
+    sys.argv = [str(arg) for arg in ("covert", *args)]
+    with pytest.raises(SystemExit) as exc:
+      main()
+    assert exc.value.code == exitcode, f"Was expecting {exitcode=} but Covert did sys.exit({exc.value.code})"
+    return capsys.readouterr()
+  return run_main
+
+
+def test_end_to_end(covert, tmp_path):
   fname = tmp_path / "crypto.covert"
 
   # Encrypt data/foo.txt into crypto.covert
-  sys.argv = "covert enc tests/data -R tests/keys/ssh_ed25519.pub -o".split() + [ str(fname) ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert("enc", "tests/data", "-R", "tests/keys/ssh_ed25519.pub", "-o", fname)
   assert not cap.out
   assert "foo" in cap.err
 
   # Decrypt
-  sys.argv = "covert dec -i tests/keys/ssh_ed25519".split() + [ str(fname), "-o", str(tmp_path)]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert("dec", "-i", "tests/keys/ssh_ed25519", fname, "-o", tmp_path)
   assert not cap.out
   assert "foo.txt" in cap.err
 
@@ -68,63 +75,53 @@ def test_end_to_end(capsys, tmp_path):
   assert data == b"test"
 
 
-def test_end_to_end_multiple(capsys, tmp_path):
-  from covert.__main__ import main
-  import sys
+def test_end_to_end_multiple(covert, tmp_path):
   fname = tmp_path / "crypto.covert"
 
   # Encrypt foo.txt into crypto.covert, with signature
-  sys.argv = "covert enc tests/data/foo.txt -i tests/keys/ssh_ed25519 --password verytestysecret -r age1cghwz85tpv2eutkx8vflzjfa9f96wad6d8an45wcs3phzac2qdxq9dqg5p -o".split() + [ str(fname) ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert(
+    'enc',
+    'tests/data/foo.txt',
+    '-i', 'tests/keys/ssh_ed25519',
+    '--password', 'verytestysecret',
+    '-r', 'age1cghwz85tpv2eutkx8vflzjfa9f96wad6d8an45wcs3phzac2qdxq9dqg5p',
+    '-o', fname,
+  )
   assert not cap.out
   assert "foo" in cap.err
 
   # Decrypt with key
-  sys.argv = "covert dec -i tests/keys/ageid-age1cghwz85tpv2eutkx8vflzjfa9f96wad6d8an45wcs3phzac2qdxq9dqg5p".split() + [ str(fname) ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert(
+    'dec',
+    '-i', 'tests/keys/ageid-age1cghwz85tpv2eutkx8vflzjfa9f96wad6d8an45wcs3phzac2qdxq9dqg5p',
+    fname,
+  )
   assert not cap.out
   assert "foo.txt" in cap.err
   assert "Key[827bc3b2:EdPK] Signature verified" in cap.err
 
   # Decrypt with passphrase
-  sys.argv = "covert dec --password verytestysecret".split() + [ str(fname) ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert('dec', '--password', 'verytestysecret', fname)
   assert not cap.out
   assert "foo.txt" in cap.err
   assert "Key[827bc3b2:EdPK] Signature verified" in cap.err
 
 
-def test_end_to_end_shortargs_armored(capsys, tmp_path):
-  from covert.__main__ import main
-  import sys
+def test_end_to_end_shortargs_armored(covert, tmp_path):
   fname = tmp_path / "crypto.covert"
 
   # Encrypt foo.txt into crypto.covert
-  sys.argv = "covert -eRao tests/keys/ssh_ed25519.pub".split() + [ str(fname), 'tests/data/foo.txt' ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert("-eRao", "tests/keys/ssh_ed25519.pub", fname, 'tests/data/foo.txt')
   assert not cap.out
   assert "foo" in cap.err
 
   # Decrypt with key
-  sys.argv = "covert -di tests/keys/ssh_ed25519".split() + [ str(fname) ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert("-di", "tests/keys/ssh_ed25519", fname)
   assert not cap.out
   assert "foo.txt" in cap.err
 
 
-def test_end_to_end_armormaxsize(capsys, tmp_path):
-  from covert.__main__ import main
-  import sys
+def test_end_to_end_armormaxsize(covert, tmp_path):
   fname = tmp_path / "test.dat"
   outfname = tmp_path / "crypto.covert"
 
@@ -134,23 +131,17 @@ def test_end_to_end_armormaxsize(capsys, tmp_path):
     f.write(b"\0")
 
   # Encrypt test.dat with armor and no padding
-  sys.argv = f"covert -eR tests/keys/ssh_ed25519.pub --pad 0 -ao".split() + [ str(outfname), str(fname) ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert("enc", fname, "-R", "tests/keys/ssh_ed25519.pub", "--pad", 0, "-ao", outfname)
   assert not cap.out
+  assert "32,505,856 📄 test.dat" in cap.err
 
   # Decrypt crypto.covert with passphrase
-  sys.argv = "covert -di tests/keys/ssh_ed25519".split() + [ str(outfname) ]
-  ret = main()
-  cap = capsys.readouterr()
-  assert not ret
+  cap = covert("-di", "tests/keys/ssh_ed25519", outfname)
   assert not cap.out
+  assert "32,505,856 📄 test.dat" in cap.err
 
 
-def test_end_to_end_large_file(capsys, tmp_path):
-  from covert.__main__ import main
-  import sys
+def test_end_to_end_large_file(covert, tmp_path):
   fname = tmp_path / "test.dat"
   outfname = tmp_path / "crypto.covert"
 
@@ -160,15 +151,11 @@ def test_end_to_end_large_file(capsys, tmp_path):
     f.write(b"\0")
 
   # Try encrypting without -o
-  sys.argv = f"covert -ea -R tests/keys/ssh_ed25519.pub".split() + [ str(fname) ]
-  main()
-  cap = capsys.readouterr()
+  cap = covert("-eaR", "tests/keys/ssh_ed25519.pub", fname, exitcode=10)
   assert not cap.out
   assert "How about -o FILE to write a file?" in cap.err
 
   # Try encrypting with -o
-  sys.argv = f"covert -eaR tests/keys/ssh_ed25519.pub -o".split() + [ str(outfname), str(fname) ]
-  main()   
-  cap = capsys.readouterr()
+  cap = covert("-eaRo", "tests/keys/ssh_ed25519.pub", outfname, fname, exitcode=10)
   assert not cap.out
   assert "The data is too large for --armor." in cap.err


### PR DESCRIPTION
Made the main function always sys.exit() - NoReturn - and with different exit status code for different errors. Cleaned up the CLI tests by implementing a helper fixture 'covert', that calls the main function.
