### PR TITLE
Support editing archives, keeping encrypted notes

### DIFF
--- a/covert/__main__.py
+++ b/covert/__main__.py
@@ -3,12 +3,13 @@ import sys
 from typing import NoReturn
 import colorama
 import covert
-from covert.cli import main_benchmark, main_dec, main_enc
+from covert.cli import main_benchmark, main_dec, main_edit, main_enc
 
 hdrhelp = """\
 Usage:
   covert enc [files] [recipients] [signatures] [-A | -o unsuspicious.dat [-a]]
   covert dec [-A | unsuspicious.dat] [-i id_ed25519] [-o filesfolder]
+  covert edit unsuspicious.dat — change text in a passphrase-protected archive
   covert benchmark
 
 Note: covert enc/dec without arguments ask for password and message. Files and
@@ -81,12 +82,14 @@ decargs = dict(
   debug='--debug'.split(),
 )
 
+editargs = dict(debug='--debug'.split(),)
 benchargs = dict(debug='--debug'.split(),)
 
 # TODO: Put mode args and help here as well
 modes = {
   "enc": main_enc,
   "dec": main_dec,
+  "edit": main_edit,
   "benchmark": main_benchmark,
 }
 
@@ -114,10 +117,12 @@ def argparse():
     args.mode, ad, modehelp = 'enc', encargs, f"{hdrhelp}\nEncryption options:\n{enchelp}"
   elif av[0] in ('dec', 'decrypt', '-d'):
     args.mode, ad, modehelp = 'dec', decargs, f"{hdrhelp}\nEncryption options:\n{enchelp}"
+  elif av[0] in ('edit'):
+    args.mode, ad, modehelp = 'edit', editargs, f"{hdrhelp}"
   elif av[0] in ('bench', 'benchmark'):
     args.mode, ad, modehelp = 'benchmark', benchargs, f"{hdrhelp}"
   else:
-    sys.stderr.write(' 💣  Invalid or missing command (enc/dec/benchmark).\n')
+    sys.stderr.write(' 💣  Invalid or missing command (enc/dec/edit/benchmark).\n')
     sys.exit(1)
 
   aiter = iter(av[1:])

--- a/covert/archive.py
+++ b/covert/archive.py
@@ -70,18 +70,23 @@ class Stage(IntEnum):
 class Archive:
 
   def __init__(self):
-    self.stage = Stage.INDEX
-    self.extrasize = 0
-    self.pos = 0
     self.index = {}
-    self.format = None
-    self.prevfile = None
     self.flist = []
+    self.reset()
+
+  def reset(self):
+    """Prepare for another decryption/encryption but keep the index."""
+    self.stage = Stage.INDEX
+    self.format = None
+    self.pos = 0
+    self.prevfile = None
     self.fidx = None
     self.fpos = None
+    self.extrasize = 0
     self.padding = 0
-    self.buffer = bytes()
     self.nextfilecb = None
+    self.buffer = bytes()
+
 
   @property
   def file(self):

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -235,18 +235,17 @@ def main_enc(args):
       if args.paste:
         pyperclip.copy(f"```\n{data}\n```\n")
         return
-      with realoutf:
-        pretty = realoutf.isatty()
+      pretty = realoutf.isatty()
+      if pretty:
+        sys.stderr.write("\x1B[1;30m```\x1B[0;34m\n")
+        sys.stderr.flush()
+      try:
+        realoutf.write(f"{data}\n".encode())
+        realoutf.flush()
+      finally:
         if pretty:
-          sys.stderr.write("\x1B[1;30m```\x1B[0;34m\n")
+          sys.stderr.write("\x1B[1;30m```\x1B[0m\n")
           sys.stderr.flush()
-        try:
-          realoutf.write(f"{data}\n".encode())
-          realoutf.flush()
-        finally:
-          if pretty:
-            sys.stderr.write("\x1B[1;30m```\x1B[0m\n")
-            sys.stderr.flush()
 
 
 def main_dec(args):
@@ -259,7 +258,14 @@ def main_dec(args):
   identities = list(sorted(identities, key=str))
   infile = open(args.files[0], "rb") if args.files else sys.stdin.buffer
   # If ASCII armored or TTY, read all input immediately (assumed to be short enough)
-  total_size = os.path.getsize(args.files[0]) if args.files else 0
+
+  # FIXME: For stdin the size is set to 50 so we try to read all of it (even if from a pipe),
+  # so that armoring can work. But this breaks pipe streaming of large files that cannot
+  # fit in RAM and tries to armor-decode very large files too. Needs to be fixed by
+  # attempting to read some to determine whether the input is small enough, and if not,
+  # use the covert.archive.CombinedIO object to consume the buffer already read and then
+  # resume streaming.
+  total_size = os.path.getsize(args.files[0]) if args.files else 50
   if infile.isatty():
     data = util.armor_decode(pyperclip.paste() if args.paste else tty.read_hidden("Encrypted message"))
     if not data:
@@ -300,10 +306,14 @@ def main_dec(args):
 
 def main_edit(args):
   if len(args.files) != 1:
-    raise ValueError("Edit mode requires name of one encrypted file to edit.")
+    raise ValueError("Edit mode requires an encrypted archive filename (or '-' to use stdio).")
+  fname = args.files[0]
   # Read all of input file (or stdin) to RAM
-  with open(args.files[0], "rb") as infile:
-    data = infile.read()
+  if fname is True:
+    data = sys.stdin.buffer.read()
+  else:
+    with open(fname, "rb") as f:
+      data = f.read()
   try:
     infile = BytesIO(util.armor_decode(data.decode()))
     args.armor = True
@@ -329,10 +339,19 @@ def main_edit(args):
   a.reset()
   a.fds = [BytesIO(f.data) for f in a.flist]
   a.random_padding()
-  # Encrypt another file with the new contents
-  with open(args.files[0], "wb") as outf:
-    for block in encrypt_file((False, [pwhash], [], []), a.encode, a):
-      outf.write(block)
+  # Encrypt in RAM...
+  out = bytearray()
+  for block in encrypt_file((False, [pwhash], [], []), a.encode, a):
+    out += block
+  # Preserve armoring if the input was armored
+  if args.armor:
+    out = f"{util.armor_encode(out)}\n".encode()
+  # Finally write output / replace the file
+  if fname is True:
+    sys.stdout.buffer.write(out)
+  else:
+    with open(fname, "wb") as f:
+      f.write(out)
 
 
 def main_benchmark(args):

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -12,7 +12,7 @@ import pyperclip
 from tqdm import tqdm
 
 from covert import lazyexec, passphrase, pubkey, tty, util
-from covert.archive import Archive
+from covert.archive import Archive, FileRecord
 from covert.blockstream import decrypt_file, encrypt_file
 from covert.util import ARMOR_MAX_SIZE, TTY_MAX_SIZE
 
@@ -296,6 +296,43 @@ def main_dec(args):
             sys.stderr.flush()
         yield pwhash
     run_decryption(infile, args, authgen())
+
+
+def main_edit(args):
+  if len(args.files) != 1:
+    raise ValueError("Edit mode requires name of one encrypted file to edit.")
+  # Read all of input file (or stdin) to RAM
+  with open(args.files[0], "rb") as infile:
+    data = infile.read()
+  try:
+    infile = BytesIO(util.armor_decode(data.decode()))
+    args.armor = True
+  except Exception:
+    infile = BytesIO(data)
+  # Decrypt everything to RAM
+  pwhash = passphrase.pwhash(passphrase.ask("Passphrase")[0])
+  a = Archive()
+  for data in a.decode(decrypt_file([pwhash], infile, a)):
+    if isinstance(data, dict): pass
+    elif isinstance(data, bool):
+      if data: a.curfile.data = bytearray()
+    else: a.curfile.data += data
+  # Edit the message (should be the first file)
+  if a.flist and a.flist[0].name is None:
+    a.flist[0].data = util.encode(tty.editor(a.flist[0].data.decode()))
+    a.flist[0].size = len(a.flist[0].data)
+  else:
+    data = util.encode(tty.editor())
+    a.flist.insert(0, FileRecord([len(data), None, {}]))
+    a.flist[0].data = data
+  # Reset archive for re-use in encryption
+  a.reset()
+  a.fds = [BytesIO(f.data) for f in a.flist]
+  a.random_padding()
+  # Encrypt another file with the new contents
+  with open(args.files[0], "wb") as outf:
+    for block in encrypt_file((False, [pwhash], [], []), a.encode, a):
+      outf.write(block)
 
 
 def main_benchmark(args):

--- a/covert/passphrase.py
+++ b/covert/passphrase.py
@@ -11,7 +11,7 @@ from covert.tty import fullscreen
 from covert.wordlist import words
 
 MINLEN = 8  # Bytes, not characters
-
+ARGON2_MEMLIMIT = 1 << 28  # Bytes (libsodium), as opposed to KiB (other libraries)
 
 def generate(n=4, sep=""):
   """Generate a password of random words without repeating any word."""
@@ -51,7 +51,7 @@ def _argon2(outlen, passwd, salt, ops):
     passwd=passwd,
     salt=salt,
     opslimit=ops,
-    memlimit=1 << 28,
+    memlimit=ARGON2_MEMLIMIT,
     alg=sodium.crypto_pwhash_ALG_ARGON2ID13,
   )
 

--- a/covert/tty.py
+++ b/covert/tty.py
@@ -6,12 +6,16 @@ from contextlib import contextmanager
 from shutil import get_terminal_size
 
 
-def editor():
+def editor(data=""):
   with fullscreen() as term:
     term.write(f'\x1B[1;1H\x1B[1;44m   〰 ENTER MESSAGE 〰   (ESC to finish)\x1B[0K\x1B[0m\n')
-    data = ""
     startrow = row = col = 0
     while True:
+      win = get_terminal_size()
+      startrow = min(max(0, row - 1), startrow)
+      startrow = max(row - win.lines + 2, startrow)
+      draw = "\x1B[0K\n".join(l[:win.columns - 1] for l in data.split("\n")[startrow:startrow + win.lines - 1])
+      term.write(f"\x1B[2;1H{draw}\x1B[0J\x1B[{row - startrow + 2};{col+1}H")
       for key in term.reader():
         lines = data.split("\n") + [""]
         if key == 'ESC':
@@ -54,11 +58,6 @@ def editor():
         if not lines[-1]:
           del lines[-1]
         data = "\n".join(lines)
-      win = get_terminal_size()
-      startrow = min(max(0, row - 1), startrow)
-      startrow = max(row - win.lines + 2, startrow)
-      draw = "\x1B[0K\n".join(l[:win.columns - 1] for l in data.split("\n")[startrow:startrow + win.lines - 1])
-      term.write(f"\x1B[2;1H{draw}\x1B[0J\x1B[{row - startrow + 2};{col+1}H")
 
 
 def read_hidden(prompt):

--- a/covert/util.py
+++ b/covert/util.py
@@ -29,9 +29,9 @@ def armor_decode(data: str) -> bytes:
   # Verify line lengths
   l = len(lines[0])
   for i, line in enumerate(lines[:-1]):
-      l2 = len(line)
-      if l2 < 76 or l2 % 4 or l2 != l:
-        raise ValueError(f"Invalid armored encoding: length {l2} of line {i + 1} is invalid")
+    l2 = len(line)
+    if l2 < 76 or l2 % 4 or l2 != l:
+      raise ValueError(f"Invalid armored encoding: length {l2} of line {i + 1} is invalid")
   data = "".join(lines)
   padding = -len(data) % 4
   if padding == 3:


### PR DESCRIPTION
Implements `covert edit` CLI command that extracts an existing archive, allows editing its text and then re-encrypts the data. Any attached files of the archive are kept without extracting them or the message to disk. The original file is overwritten.

This function is intended to allow adding and removing attachments, as well as using public keys, but for now it is limited to message editing and passphrases. Also, all data must fit in RAM, as no streaming is yet implemented for this mode.

Fixes #57