### PR TITLE
Added Montgomery module and minor changes in Elliptic module

### DIFF
--- a/covert/elliptic/__init__.py
+++ b/covert/elliptic/__init__.py
@@ -14,6 +14,7 @@
 # Public symbols are imported here. These are very low level primitives.
 # Lower case constants are scalars (int or fe), upper case are EdPoints.
 
+from . import mont
 from .ed import LO, ZERO, D, EdPoint, G, L, dirty_scalar, secret_scalar
 from .eddsa import ed_sign, ed_verify
 from .elligator import ElligatorError, egcreate, eghide, egreveal

--- a/covert/elliptic/mont.py
+++ b/covert/elliptic/mont.py
@@ -1,0 +1,59 @@
+from . import ed
+from .scalar import fe, minus1, one, zero
+
+# Curve25519 constants on Montgomery curve: B v2 = u3 + A u2 + u
+A = fe(486662)  # = fe(2) * (ed.a + ed.d) / (ed.a - ed.d)
+B = one
+
+# The point at infinity is represented by u coordinate value minus1 because
+#  - No established standard in other libraries (most use zero which is a different low order point)
+#  - This is the only number for which there is no birational conversion to Ed25519 (division by zero)
+#  - This is not a valid point on the curve (v2 = 486660 which is not square)
+#  - The Montgomery ladder misbehaves with this value
+
+def v(u: fe) -> fe:
+  """Calculate the v coordinate for a point, checking point validity as well."""
+  v2 = u**3 + A * u.sq + u
+  if v2.is_square: return v2.sqrt
+  if u == minus1:
+    raise ValueError("Curve25519 point at infinity does not have coordinates")
+  raise ValueError(f"Curve25519 {u=} is not a valid point")
+
+
+def scalarmult(s: int, u: fe):
+  """Multiply point u coordinate by scalar s in Curve25519"""
+  if hasattr(u, "mont"): u = u.mont  # type: ignore
+  s %= 8 * ed.q
+  # Special care of two low order points that the algorithm mishandles
+  if u == minus1: return minus1  # Point at infinity
+  if u == zero: return zero if s & 1 else minus1  # Low order point with order 2
+  # Montgomery ladder
+  # In projective coordinates, to avoid divisions: u = X / Z
+  x2, z2 = one, zero  # "zero" point
+  x3, z3 = u, one     # "one" point
+  swap = False
+  for n in reversed(range(s.bit_length())):
+    bit = bool(s & 1 << n)
+    swap ^= bit
+    if swap:
+      x2, x3 = x3, x2
+      z2, z3 = z3, z2
+    swap = bit  # anticipates one last swap after the loop
+
+    # Montgomery ladder step: replaces (P2, P3) by (P2*2, P2+P3) with differential addition
+    a, b = x2 + z2, x2 - z2
+    aa, bb = a.sq, b.sq
+    da = a * (x3 - z3)
+    db = b * (x3 + z3)
+    e = aa - bb
+    # Output
+    x3, z3 = (da + db).sq, (da - db).sq * u
+    x2, z2 = aa * bb, (bb + fe(121666) * e) * e
+
+  # last swap is necessary to compensate for the xor trick
+  if swap:
+    x2, x3 = x3, x2
+    z2, z3 = z3, z2
+
+  # normalises the coordinates: u == X / Z
+  return x2 / z2 if z2 != zero else zero if x2 == zero else minus1

--- a/covert/elliptic/scalar.py
+++ b/covert/elliptic/scalar.py
@@ -23,7 +23,7 @@ class fe:
   def __repr__(self): return value_name(self)
   def __str__(self): return bytes(self).hex()
   def __bytes__(self): return self.val.to_bytes(32, 'little')
-  def bit(self, n: int): return bool(self.val & (1 << n))
+  def bit(self, n: int): return bool(self.val & 1 << n)
 
   def __eq__(self, other):
     # Note: if we return NotImplemented, Python does object comparison and returns False
@@ -52,7 +52,7 @@ class fe:
   def inv(self) -> fe: return self**-1
 
   @cached_property
-  def is_negative(self) -> bool: return self.val % p > p2
+  def is_negative(self) -> bool: return self.val > p2
 
   # Legendre symbol:
   # -  0 if n is zero
@@ -95,7 +95,7 @@ class fe:
   def invsqrt(self) -> fe:
     """Fast 1/sqrt(x) mod p, more black magic than Carmack's"""
     isr = self**p58
-    quartic = self * isr**2
+    quartic = self * isr.sq
     if quartic == minus1 or quartic == -sqrtm1: isr *= sqrtm1
     isr.is_square = quartic == one or quartic == minus1
     return isr

--- a/tests/test_elliptic.py
+++ b/tests/test_elliptic.py
@@ -50,6 +50,11 @@ def test_mont():
   Led = [EdPoint.from_mont(mont.scalarmult(s, L), s >= 4) for s in range(8)]
   assert Led == LO
 
+  # Very special low order points
+  assert mont.scalarmult(11, ZERO) == ZERO.mont
+  assert mont.scalarmult(3, LO[4]) == LO[4].mont
+  assert mont.scalarmult(4, LO[4]) == ZERO.mont
+
   # Any point times 8q should be point at infinity (ZERO)
   assert mont.scalarmult(4 * q, 2 * D) == ZERO.mont
 

--- a/tests/test_elliptic.py
+++ b/tests/test_elliptic.py
@@ -38,6 +38,33 @@ def test_ed():
   K = k * G
   assert bytes(K).hex() == edpk.hex()
 
+def test_mont():
+  assert mont.scalarmult(0, D.mont) == ZERO.mont
+  assert mont.scalarmult(1, D.mont) == D.mont
+
+  # Low order points
+  Lmont = [mont.scalarmult(s, L) for s in range(8)]
+  Lexpected = [ZERO.mont, L.mont, LO[2].mont, LO[3].mont, LO[4].mont, LO[3].mont, LO[2].mont, LO[1].mont]
+  assert Lmont == Lexpected
+
+  Led = [EdPoint.from_mont(mont.scalarmult(s, L), s >= 4) for s in range(8)]
+  assert Led == LO
+
+  # Any point times 8q should be point at infinity (ZERO)
+  assert mont.scalarmult(4 * q, 2 * D) == ZERO.mont
+
+  # Test v coordinate recovery
+  assert mont.v(fe(9)) == fe(14781619447589544791020593568409986887264606134616475288964881837755586237401)
+
+  with pytest.raises(ValueError) as exc:
+    mont.v(fe(2))
+  assert "not a valid point" in str(exc.value)
+
+  with pytest.raises(ValueError) as exc:
+    mont.v(ZERO.mont)
+  assert "point at infinity" in str(exc.value)
+
+
 def test_hashmap():
   # Just hitting the __hash__ functions
   assert len({fe(i * p) for i in range(2)}) == 1


### PR DESCRIPTION
Improved low order point encoding that is now inconsistent with libsodium and monocypher but more logical and able to represent all low order points correctly. The point at infinity is encoded as u=-1 (mod p), which is not a curve point and has no birational mapping to Ed25519 anyway (division by zero), while everything else uses the standard mapping and encoding specified in RFCs. Similarly the Ed25519 neutral element (ZERO, equivalent to the point at infinity) cannot use birational equivalency as it too causes division by zero due to its y coordinate being 1.