### PR TITLE
Switch to deterministic signatures

### DIFF
--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -4,7 +4,6 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from hashlib import sha512
-from secrets import token_bytes
 
 from nacl.exceptions import CryptoError
 

--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -244,7 +244,7 @@ def encrypt_file(auth, blockinput, a):
   a.filehash = blkhash
   # Add signature blocks
   for key in identities:
-    signature = xed_sign(key.sk, blkhash, token_bytes(64))
+    signature = xed_sign(key.sk, blkhash, blkhash)  # blkhash is both the message and the nonce
     nsig = sha512(blkhash + key.pk).digest()[:12]
     ksig = blkhash[:32]
     yield chacha.encrypt(signature, None, nsig, ksig)


### PR DESCRIPTION
XEdDSA requires a 64-byte nonce as additional security against such a case where the same message was signed many times and a computational error or a side channel leak could then reveal the secret key. Such additional security is not of any use in the case of Covert where the message itself is always different, and would not be necessary in any case if an implementation was free of side channel leaks and the CPU was not broken. There is discussion of this trade off in the Signal XEdDSA specification and in RFC 6979 as well as in Bernstein's Ed25519 paper.

The message being signed in Covert is the file hash which should already be unique for each file, even if everything else stays the same, because it depends on the file nonce which is randomised. This patch removes the unnecessary use of additional random bytes on signatures and instead implements deterministic XEdDSA by using the file hash as both the message and the nonce (staying compatible with XEdDSA which requires a 64-byte nonce, rather than omitting the nonce from SHA-512 hashing).

The choice of nonce in signatures does not affect signature verification, and thus each implementation is free to do this whichever way they prefer without compatibility concerns. The nonce only affects the secret random commitment `r`, whose corresponding public key `R` is published as part of the signature.
