### PR TITLE
Fix blockstream decryption bug causing signature verification failures

### DIFF
--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -115,7 +115,7 @@ class BlockStream:
           nextlen = int.from_bytes(block[-3:], "little")
           self.blkhash = sha512(self.blkhash + self.ciphertext[p + elen - 16:p + elen]).digest()
           yield block[:-3]
-          if len(self.q) < self.workers: break  # Buffer more blocks
+          break  # Buffer more blocks
         except CryptoError:
           # Reset the queue and try again at failing pos with new nextlen if available
           for qq in self.q:

--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -123,7 +123,7 @@ class BlockStream:
           self.q.clear()
           extlen = nextlen + 19
           if elen == extlen:
-            raise CryptoError(f"Failed to decrypt block {self.key.hex()} {nblk.hex()} at ({self.ciphertext[p:p+extlen].hex()})[{p}:{p + extlen}]") from None
+            raise ValueError(f"Data corruption: Failed to decrypt ciphertext block of {extlen} bytes") from None
           self.nonce = noncegen(nblk)
           self.pos = self._add_to_queue(p, extlen)
     for qq in self.q:

--- a/tests/test_blockstream.py
+++ b/tests/test_blockstream.py
@@ -70,7 +70,7 @@ def test_latencies(values, expected_seq):
     next(e)
 
 
-@pytest.mark.parametrize("size", [1, 5000, 20 << 20])
+@pytest.mark.parametrize("size", [1, 1100, 5000, 20 << 20])
 def test_encrypt_decrypt(size):
   """Verify that the blockstream level encrypt-decrypt cycle works as intended."""
 


### PR DESCRIPTION
- The blockstream `pos` variable was not updated correctly in some special cases, in particular with files slightly above 1024 bytes.
- Added test for such case.
- Removed unused filelen and filepos variables.
- Don't guess initial nextlen, use block0's known size.

Fix #79
