### PR TITLE
Implement ID store in a file

### DIFF
--- a/covert/__main__.py
+++ b/covert/__main__.py
@@ -45,6 +45,7 @@ Covert {covert.__version__} - A file and message encryptor with strong anonymity
 class Args:
 
   def __init__(self):
+    self.idname = ""
     self.files = []
     self.wideopen = None
     self.askpass = 0
@@ -60,6 +61,7 @@ class Args:
 
 
 encargs = dict(
+  idname='-I --id'.split(),
   askpass='-p --passphrase'.split(),
   passwords='--password'.split(),
   wideopen='--wide-open'.split(),
@@ -74,6 +76,7 @@ encargs = dict(
 )
 
 decargs = dict(
+  idname='-I --id'.split(),
   askpass='-p --passphrase'.split(),
   passwords='--password'.split(),
   identities='-i --identity'.split(),

--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -154,7 +154,7 @@ class BlockStream:
     a.signatures = []
     # Signature verification
     if a.index.get('s'):
-      signatures = [pubkey.Key(edpk=k) for k in a.index['s']]
+      signatures = [pubkey.Key(pk=k) for k in a.index['s']]
       for key in signatures:
         sz = self._read(self.end - self.pos + 80)
         if sz < 80:

--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -170,7 +170,7 @@ class BlockStream:
           continue
         try:
           xed_verify(key.pk, self.blkhash, signature)
-          a.signatures.append((True, key, 'Signature verified'))
+          a.signatures.append((True, key, 'Signed by'))
         except CryptoError:
           a.signatures.append((False, key, 'Forged signature'))
 

--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -8,7 +8,7 @@ from secrets import token_bytes
 
 from nacl.exceptions import CryptoError
 
-from covert import chacha, pubkey
+from covert import chacha, pubkey, ratchet
 from covert.cryptoheader import Header, encrypt_header
 from covert.elliptic import xed_sign, xed_verify
 from covert.util import noncegen
@@ -44,7 +44,9 @@ class BlockStream:
 
   def authenticate(self, anykey):
     """Attempt decryption using secret key or password hash"""
-    if isinstance(anykey, pubkey.Key):
+    if isinstance(anykey, ratchet.Ratchet):
+      self.header.try_ratchet(anykey)
+    elif isinstance(anykey, pubkey.Key):
       self.header.try_key(anykey)
     else:
       self.header.try_pass(anykey)

--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -23,6 +23,8 @@ def decrypt_file(auth, f, archive):
         with suppress(CryptoError):
           b.authenticate(a)
           break
+      # In case auth is a generator, close it immediately (otherwise would be delayed)
+      if hasattr(auth, "close"): auth.close()
     yield from b.decrypt_blocks()
     b.verify_signatures(archive)
 

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -280,8 +280,8 @@ def main_enc(args):
         [f"🔗 {r}" for r in recipients] + [f"🔑 {a}" for a in vispw] + (numpasswd - len(vispw)) * ["🔑 <pw>"]
       )
       methods += f' 🔷 {a.filehash[:12].hex()}'
-    for id in signatures:
-      methods += f"  🖋️ {id}"
+    for s in signatures:
+      methods += f"  🖋️ {s}"
     if methods:
       lock += f"    {methods}"
     if args.outfile:

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -187,15 +187,12 @@ def main_enc(args):
         stin = sys.stdin.buffer
       args.files = [stin] + [f for f in args.files if f != True]
     # Collect the password hashing results
-    if (args.idname or passwords) and sys.stderr.isatty():
-      sys.stderr.write("Password hashing... ")
-      sys.stderr.flush()
-    if args.idname: idpwhash = idpwhasher.result()
-    pwhashes = set(pwhasher)
-    if (args.idname or passwords) and sys.stderr.isatty():
-      sys.stderr.write("\r\x1B[0K")
-      sys.stderr.flush()
-    del passwords
+    pwhashes = set()
+    if args.idname or passwords:
+      with tty.status("Password hashing... "):
+        if args.idname: idpwhash = idpwhasher.result()
+        pwhashes = set(pwhasher)
+      del passwords
     # ID store update
     if args.idname:
       # Try until the passphrase works

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -501,7 +501,7 @@ def main_id(args):
     if tagself and tagself not in ids:
       ids[tagself] = dict()
       if not selfkey:
-        sys.stderr.write(f" 🔗 {tagself} keypair created\n")
+        sys.stderr.write(f" 🧑 {tagself} keypair created\n")
         selfkey = pubkey.Key()
     if selfkey:
       ids[tagself]["I"] = selfkey.sk
@@ -522,6 +522,10 @@ def main_id(args):
       elif "i" in value:
         pk = pubkey.encode_age_pk(pubkey.Key(pk=value["i"]))
         print(f"{key:15} {pk}")
+      # Ratchet info
+      if (r := value.get("r")):
+        state = "with forward secrecy" if r["RK"] else "initialising (messages sent but no response yet)"
+        print(f"   conversation {state}")
 
 
 def main_benchmark(args):

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -407,6 +407,86 @@ def main_edit(args):
       f.write(out)
 
 
+def main_id(args):
+  if len(args.files) > 1:
+    raise ValueError("Argument error, one ID at most should be specified")
+  if args.delete_entire_idstore:
+    if args.files:
+      raise ValueError("No ID should be provided with --delete-entire-idstore")
+    try:
+      idstore.delete_entire_idstore()
+      sys.stderr.write(f"{idstore.idfilename} shredded and deleted.\n")
+    except FileNotFoundError:
+      sys.stderr.write(f"{idstore.idfilename} does not exist.\n")
+    return
+  if args.files:
+    parts = args.files[0].split(":", 1)
+    local = parts[0]
+    peer = parts[1] if len(parts) == 2 else ""
+    tagself = f"id:{local}"
+    tagpeer = f"id:{local}:{peer}" if peer else None
+  else:
+    tagself = tagpeer = None
+  if args.delete and not tagself:
+    raise ValueError("Need an ID of form yourname or yourname:peername to delete.")
+  if args.recipients:
+    if not tagpeer:
+      raise ValueError("Need an ID of form yourname:peername to assign a public key")
+    if len(args.recipients) > 1:
+      raise ValueError("Only one public be specified for ID store")
+  if args.identities:
+    if not tagself:
+      raise ValueError("Need an ID to assign a secret key.")
+    if len(args.identities) > 1:
+      raise ValueError("Only one secret key may be specified for ID store")
+  create_idstore = not idstore.idfilename.exists()
+  if create_idstore:
+    if not tagself:
+      raise ValueError("To create a new ID store, specify an ID to create e.g.\n  covert id alice\n")
+    sys.stderr.write(f" 🗄️  Creating {idstore.idfilename}\n")
+  # Passphrases
+  idpass = newpass = None
+  if not create_idstore:
+    idpass = passphrase.ask("Master ID passphrase")[0]
+  with ThreadPoolExecutor(max_workers=2) as executor:
+    pwhasher = executor.submit(passphrase.pwhash, idpass) if idpass is not None else None
+    newhasher = None
+    if args.askpass or create_idstore:
+      newpass, visible = passphrase.ask("New Master ID passphrase", create=5)
+      newhasher = executor.submit(passphrase.pwhash, newpass)
+      if visible:
+        sys.stderr.write(f" 📝  Master ID passphrase: \x1B[32;1m{newpass.decode()}\x1B[0m\n")
+    with tty.status("Password hashing... "):
+      idhash = pwhasher.result() if pwhasher else None
+      newhash = newhasher.result() if newhasher else None
+    del idpass, newpass, pwhasher, newhasher
+  # Update ID store
+  for ids in idstore.update(idhash, new_pwhash=newhash):
+    if args.delete:
+      if tagpeer:
+        del ids[tagpeer]
+      else:
+        del ids[tagself]
+      return
+    if tagself and not tagpeer and tagself not in ids:
+      ids[tagself] = dict()
+      ids[tagself]["I"] = pubkey.Key().sk
+    if args.identities or args.recipients:
+      raise ValueError("Setting keys is not yet implemented")  # TODO
+    # Print keys
+    for key, value in ids.items():
+      if tagself and key not in (tagself, tagpeer): continue
+      if "I" in value:
+        k = pubkey.Key(sk=value["I"])
+        sk = pubkey.encode_age_sk(k)
+        pk = pubkey.encode_age_pk(k)
+        print(f"{key:15} {pk}")
+        if args.secret: print(f" ╰─ {sk}")
+      elif "i" in value:
+        pubkey.encode_age_pk(pubkey.Key(pk=value["i"]))
+        print(f"{key:15} {pk}")
+
+
 def main_benchmark(args):
 
   def noop_read(block):

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -155,11 +155,11 @@ def main_enc(args):
   if args.idname:
     if len(signatures) > 1: raise ValueError("Only one secret key may be associated with an identity.")
     if len(recipients) > 1: raise ValueError("Only one recipient key may be associated with an identity.")
-    if idstore.idfilename().exists():
+    if idstore.idfilename.exists():
       idpass, _ = passphrase.ask("Master ID passphrase")
     else:
       idpass = util.encode(passphrase.generate(5))
-      sys.stderr.write(f" 🗄️  Master ID passphrase: \x1B[32;1m{idpass.decode()}\x1B[0m (creating {idstore.idfilename()})\n")
+      sys.stderr.write(f" 🗄️  Master ID passphrase: \x1B[32;1m{idpass.decode()}\x1B[0m (creating {idstore.idfilename})\n")
   numpasswd = args.askpass + len(args.passwords)
   passwords, vispw = [], []
   for i in range(args.askpass):

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -460,12 +460,12 @@ def main_id(args):
   selfkey = peerkey = None
   if args.recipients or args.recipfiles:
     if not tagpeer: raise ValueError("Need an ID of form yourname:peername to assign a public key")
-    if len(args.recipients) + len(args.recipfiles) > 1: raise ValueError("Only one public be specified for ID store")
+    if len(args.recipients) + len(args.recipfiles) > 1: raise ValueError("Only one public key may be specified for ID store")
     peerkey = pubkey.decode_pk(args.recipients[0]) if args.recipients else pubkey.read_pk_file(args.recipfiles[0])[0]
   if args.identities:
     if not tagself: raise ValueError("Need an ID to assign a secret key.")
     if len(args.identities) > 1: raise ValueError("Only one secret key may be specified for ID store")
-    peerkey = pubkey.read_sk_any(args.identities[0])
+    selfkey = pubkey.read_sk_any(args.identities[0])[0]
   # First run UX
   create_idstore = not idstore.idfilename.exists()
   if create_idstore:

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -215,7 +215,7 @@ def main_enc(args):
   a = Archive()
   a.file_index(args.files)
   if signatures:
-    a.index['s'] = [s.edpk for s in signatures]
+    a.index['s'] = [s.pk for s in signatures]
   # Output files
   realoutf = open(args.outfile, "wb") if args.outfile else sys.stdout.buffer
   if args.armor or not args.outfile and sys.stdout.isatty():

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -117,6 +117,8 @@ def run_decryption(infile, args, b, idkeys):
   b.verify_signatures(a)
   if b.header.authkey:
     sys.stderr.write(f" 🔑 Unlocked with {b.header.authkey}\n")
+  elif b.header.ratchet:
+    sys.stderr.write(f" 🔑 Conversation {b.header.ratchet.idkey}\n")
   sys.stderr.write(f' 🔷 File hash: {a.filehash[:12].hex()}\n')
   for valid, key, text in a.signatures:
     key = idkeys.get(key, key)

--- a/covert/cli.py
+++ b/covert/cli.py
@@ -119,9 +119,9 @@ def run_decryption(infile, args, b, idkeys):
   for valid, key, text in a.signatures:
     key = idkeys.get(key, key)
     if valid:
-      sys.stderr.write(f" ✅ {key} {text}\n")
+      sys.stderr.write(f" ✅ {text} {key}\n")
     else:
-      sys.stderr.write(f"\x1B[1;31m ❌ {key} {text}\x1B[0m\n")
+      sys.stderr.write(f"\x1B[1;31m ❌ {text} {key}\x1B[0m\n")
 
 
 def main_enc(args):

--- a/covert/clihelp.py
+++ b/covert/clihelp.py
@@ -1,0 +1,169 @@
+import sys
+from typing import NoReturn
+
+import covert
+
+T = "\x1B[1;44m"  # titlebar (white on blue)
+H = "\x1B[1;37m"  # heading (bright white)
+C = "\x1B[0;34m"  # command (dark blue)
+F = "\x1B[1;34m"  # flag (light blue)
+D = "\x1B[1;30m"  # dark / syntax markup
+N = "\x1B[0m"     # normal color
+
+usage = dict(
+  enc=f"""\
+{C}covert {F}enc --id{N} you:them {D}[{N}{F}-r{N} pubkey {D}|{N} {F}-R{N} pkfile{D}]  ⋯{N}
+{C}covert {F}enc {D}[{F}-i {N}id.key{D}] [{F}-r {N}pubkey {D}|{N} {F}-R {N}pkfile {D}|{F} -p {D}|{F} --wide-open{D}]…  ⋯
+        ⋯  [{F}--pad {N}5{D}] [{F}-A {D}| [{F}-o {N}cipher.dat {D}[{F}-a{D}]] [{N}file.jpg{D}]…{N}
+""",
+  dec=f"{C}covert {F}dec {D}[{F}--id {N}you:them{D}] [{F}-i {N}id.key{D}] [{F}-A {D}|{N} cipher.dat{D}] [{F}-o {N}files/{D}]{N}\n",
+  id=f"{C}covert {F}id {D}[{N}you:them{D}] [{N}options{D}] —{N} create/manage ID store of your keys\n",
+  edit=f"{C}covert {F}edit {N}cipher.dat {D}—{N} securely keep notes with passphrase protection\n",
+  bench=f"{C}covert {F}benchmark {D}—{N} run a performance benchmark for decryption and encryption\n",
+)
+
+usagetext = dict(
+  enc=f"""\
+Encrypt a message and/or files. The first form uses ID store, while the second
+does not and instead takes all keys on the command line. When no files are
+given or {F}-{N} is included, Covert asks for message input or reads stdin.
+
+  {F}--id {N}alice:bob    Use ID store for local (alice) and peer (bob) keys
+  {F}-i {N}seckey         Sign the message with your secret key
+  {F}-r {N}pubkey {F}-R{N} file Encrypt the message for this public key
+  {F}-p{N}                Passphrase encryption (default when no other options)
+  {F}--wide-open{N}       Allow anyone to open the file (no keys or passphrase)
+
+  {F}--pad{N} PERCENT     Preferred random padding amount (default 5 %)
+  {F}-o{N} FILENAME       Output file (binary ciphertext that looks entirely random)
+  {F}-a{N}                ASCII/text output (default for terminal/clipboard)
+  {F}-A{N}                Auto copy&paste of ciphertext (desktop use)
+
+With ID store, no keys need to be defined on command line, although as a
+shortcut one may store a new peer by specifiying a previously unused peer name
+and his public key by {C}covert {F}enc --id {N}you:newpeer{F} -r{N} key {D}⋯{N}  avoiding the use
+of the {F}id{N} subcommand to add the peer public key first. Conversations already
+established use forward secret keys and should have no key specified on {F}enc{N}.
+
+Folders may be specified as input files and they will be stored recursively.
+Any paths given on command line are stripped off the stored names, such that
+each item appears at archive root, avoiding accidental leakage of metadata.
+""",
+  dec=f"""\
+Decrypt Covert archive. Tries decryption with options given on command line,
+and with all conversations and keys stored in ID store.
+
+  {F}--id {N}alice:bob    Store the sender as "bob" if not previously known
+  {F}-i {N}seckey         Sign the message with your secret key
+  {F}-r {N}pubkey {F}-R{N} file Encrypt the message for this public key
+  {F}-p{N}                Passphrase encryption (default when no other options)
+  {F}--wide-open{N}       Allow anyone to open the file (no keys or passphrase)
+  {F}-o{N} folder         Folder where to extract any attached files.
+  {F}-A{N}                Auto copy&paste of ciphertext (desktop use)
+""",
+  edit=f"""\
+Avoids having to extract the message in plain text for editing, which could
+leave copies on disk unprotected. Use {C}covert {F}enc{N} with a passphrase to create
+the initial archive. Attached files and other data are preserved even though
+editing overwrites the entire encrypted file.
+""",
+  id=f"""\
+The ID store keeps your encryption keys stored securely and enables messaging
+with forward secrecy. You only need to enter anyone's public key the first
+time you send them a message and afterwards all replies use temporary keys
+which change with each message sent and received.
+
+  {F}-s --secret{N}       Show secret keys (by default only shows public keys)
+  {F}-p --passphrase{N}   Change Master ID passphrase
+  {F}-r {N}pk {F}-R {N}pkfile   Change/set the public key associated with ID local:peer
+  {F}-i {N}seckey         Change the secret key of the given local ID
+  {F}-D --delete{N}       Delete the ID (local and all its peers, or the given peer)
+  {F}--delete-entire-idstore{N}  Securely erase the entire ID storage
+
+The storage is created when you run {C}covert {F}id{N} yourname. Be sure to
+write down the master passphrase created or change it to one you can remember.
+Multiple local IDs can be created for separating one's different tasks and
+their contacts, but all share the same master passphrase.
+
+The ID names are for your own information and are never included in messages.
+Avoid using spaces or punctuation on them. Notice that your local ID always
+comes first, and any peer is separated by a colon. Deletion of a local ID also
+removes all public keys and conversations attached to it.
+""",
+)
+
+cmdhelp = {k: f"{usage[k]}\n{usagetext.get(k, '')}".rstrip("\n") + "\n" for k in usage}
+
+introduction = f"Covert {covert.__version__} - A file and message encryptor with strong anonymity"
+if len(introduction) > 78:  # git version string is too long
+  introduction = f"Covert {covert.__version__} - A file and message encryptor"
+
+introduction = f"""\
+{T}{introduction:78}{N}
+ 💣  Things encrypted with this developer preview mayn't be readable evermore
+"""
+
+shorthelp = f"""\
+{introduction}
+{"".join(usage.values())}
+Getting started: optionally create an ID ({C}covert {F}id{N} yourname), then use the
+{F}enc{N} command to send messages and {F}dec{N} to receive them. You won't need most
+of the options but see the help for more info. Commonly used options:
+
+  {F}--id {N}alice:bob    Use ID store for local (alice) and peer (bob) keys
+  {F}-i {N}seckey         Your secret key file (e.g .ssh/id_ed25519) or keystring
+  {F}-r {N}pubkey {F}-R{N} file Their public key, or {F}-R{N} github:username {D}|{N} bob.pub
+  {F}-A{N}                Auto copy&paste of ciphertext (desktop use)
+  {F}--help --version{N}  Useful information. Help applies to subcommands too.
+"""
+
+keyformatshelp = f"""\
+{H}Supported key formats and commands to generate keys:{N}
+
+* Age:         {C}covert {F}id{N} yourname      (Covert natively uses Age's key format)
+* Minisign:    {C}minisign {F}-R{N}
+* SSH ed25519: {C}ssh-keygen {F}-t ed25519{N}   (other SSH key types are not supported)
+* WireGuard:   {C}wg {F}genkey {C}| tee {N}secret.key {C}| wg {F}pubkey{N}
+"""
+
+exampleshelp = f"""\
+{H}Examples:{N}
+
+* To encrypt a message using an ssh-ed25519 public key, run:
+  - {C}covert {F}enc -R {N}github:myfriend {F}-o{N} file
+  - {C}covert {F}enc -R {N}~/.ssh/myfriend.pub {F}-o{N} file
+  - {C}covert {F}enc -r {N}AAAAC3NzaC1lZDI1NTE5AAAA... {F}-o{N} file
+
+* To decrypt a message using a private ssh-ed25519 key file, run:
+  - {C}covert {F}dec -i {N}~/.ssh/id_ed25519 file
+
+* Messaging and key storage with ID store:
+  - {C}covert {F}id {N}alice                      Add your ID (generate new or {F}-i{N} key)
+  - {C}covert {F}id {N}alice:bob {F}-R{N} github:bob    Add bob as a peer for local ID alice
+  - {C}covert {F}enc --id {N}alice:bob            Encrypt a message using idstore
+  - {C}covert {F}enc --id {N}alice:charlie {F}-r{N} pk  Adding a peer (on initial message)
+  - {C}covert {F}dec{N}                           Uses idstore for decryption
+"""
+
+allcommands = '\n\n'.join(cmdhelp.values())
+
+fullhelp = f"""\
+{introduction}
+{allcommands}
+
+{keyformatshelp}
+{exampleshelp}"""
+
+def print_help(modehelp: str = None, error: str = None) -> NoReturn:
+  stream = sys.stderr if error else sys.stdout
+  if modehelp is None: stream.write(shorthelp)
+  elif (h := cmdhelp.get(modehelp)): stream.write(h)
+  else: stream.write(fullhelp)
+  if error:
+    stream.write(f"\n{error}\n")
+    sys.exit(1)
+  sys.exit(0)
+
+def print_version() -> NoReturn:
+  print(f"Covert {covert.__version__}")
+  sys.exit(0)

--- a/covert/cryptoheader.py
+++ b/covert/cryptoheader.py
@@ -3,13 +3,18 @@ from contextlib import suppress
 
 from nacl.exceptions import CryptoError
 
-from covert import chacha, passphrase, pubkey, util
+from covert import chacha, passphrase, pubkey, ratchet, util
 
 
 def encrypt_header(auth):
   wideopen, pwhashes, recipients, identities = auth
   assert wideopen or pwhashes or recipients, "Must have an authentication method defined"
   assert not wideopen or not (pwhashes or recipients), "Cannot have auth with wide-open"
+  # Ratchet mode special handling
+  if isinstance(recipients, ratchet.Ratchet):
+    header, key = recipients.send()  # Ratchet.send
+    print(len(header), key.hex())
+    return header, util.noncegen(header[:12]), key
   # Ensure uniqueness
   pwhashes = set(pwhashes)
   recipients = set(recipients)
@@ -50,6 +55,11 @@ class Header:
       # Try wide-open
       self._find_block0(bytes(32), 12)
       self.slot = "wide-open"
+
+  def try_ratchet(self, r: ratchet.Ratchet):
+    authkey = r.receive(self.ciphertext)
+    self._find_block0(authkey, 50)
+    self.slot = "conversation"
 
   def try_key(self, recvkey):
     self._find_slots(pubkey.derive_symkey(self.nonce, recvkey, self.eph))

--- a/covert/cryptoheader.py
+++ b/covert/cryptoheader.py
@@ -43,6 +43,7 @@ class Header:
     self.eph = pubkey.Key(pkhash=self.ciphertext[:32])
     self.slot = "locked"
     self.key = None
+    self.authkey = None
     self.block0pos = None
     self.block0len = None
     with suppress(CryptoError):
@@ -52,6 +53,7 @@ class Header:
 
   def try_key(self, recvkey):
     self._find_slots(pubkey.derive_symkey(self.nonce, recvkey, self.eph))
+    self.authkey = recvkey
 
   def try_pass(self, pwhash):
     authkey = passphrase.authkey(pwhash, self.nonce)

--- a/covert/cryptoheader.py
+++ b/covert/cryptoheader.py
@@ -49,6 +49,7 @@ class Header:
     self.slot = "locked"
     self.key = None
     self.authkey = None
+    self.ratchet = None
     self.block0pos = None
     self.block0len = None
     with suppress(CryptoError):
@@ -60,6 +61,7 @@ class Header:
     authkey = r.receive(self.ciphertext)
     self._find_block0(authkey, 50)
     self.slot = "conversation"
+    self.ratchet = r
 
   def try_key(self, recvkey):
     self._find_slots(pubkey.derive_symkey(self.nonce, recvkey, self.eph))

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -1,14 +1,18 @@
-from covert import passphrase, pubkey
-from covert.blockstream import encrypt_file, decrypt_file
-from covert.archive import Archive
-from pathlib import Path
 import mmap
-import subprocess
 import os
+import subprocess
+from contextlib import suppress
+from pathlib import Path
+from xdg import xdg_config_home
 
-def idfilename():
-  # TODO: Use xdg paths such as ~/.config/covert/idstore on unix systems
-  return Path.home() / ".covert" / "idstore"
+from covert import passphrase, pubkey
+from covert.archive import Archive
+from covert.blockstream import decrypt_file, encrypt_file
+
+
+confdir = xdg_config_home() / ".covert"
+idfilename = confdir / "idstore"
+
 
 def create(pwhash, idstore=None):
   a = Archive()
@@ -16,41 +20,36 @@ def create(pwhash, idstore=None):
   # Encrypt in RAM...
   out = b"".join(b for b in encrypt_file((False, [pwhash], [], []), a.encode, a))
   fn = idfilename()
-  confdir = idfilename().parent
   if not confdir.exists():
     confdir.mkdir(parents=True)
     if os.name == "posix":
       confdir.chmod(0o700)
       # Attempt to disable CoW (in particular with btrfs and zfs)
-      ret = subprocess.run(["chattr", "+C", confdir], capture_output=True)
+      ret = subprocess.run(["chattr", "+C", confdir], capture_output=True)  # nosec
   # Write the ID file
   with open(fn, "xb") as f:
     if os.name == "posix": fn.chmod(0o600)
     f.write(out)
 
-# pwhash = passphrase.pwhash(passphrase.ask("ID Master Passphrase")[0])
 
 def update(pwhash, allow_create=True):
-  fn = idfilename()
-  if allow_create and not fn.exists():
+  if allow_create and not idfilename.exists():
     idstore = {}
     yield idstore
     if idstore: create(pwhash, idstore)
     return
-  with open(fn, "r+b") as f, mmap.mmap(f.fileno(), 0) as m:
+  with open(idfilename, "r+b") as f, mmap.mmap(f.fileno(), 0) as m:
     # Decrypt everything to RAM
     a = Archive()
     for data in a.decode(decrypt_file([pwhash], m, a)):
       if isinstance(data, dict):
-        if not "I" in data:
-          data["I"] = []
+        if not "I" in data: data["I"] = dict()
       elif isinstance(data, bool):
         if data: a.curfile.data = bytearray()
       else: a.curfile.data += data
-    try:
+    # Yield the ID store for operations but do an update even on break/return etc
+    with suppress(GeneratorExit):
       yield a.index["I"]
-    except StopIteration:
-      pass
     # Reset archive for re-use in encryption
     a.reset()
     a.fds = [BytesIO(f.data) for f in a.flist]
@@ -60,27 +59,39 @@ def update(pwhash, allow_create=True):
     # Overwrite the ID file
     if len(m) < len(out): m.resize(len(out))
     m[:len(out)] = out
-    if len(m) > 2.0 * len(out): m.resize(len(m))
+    if len(m) > 2 * len(out): m.resize(len(m))
+
 
 def profile(pwhash, idstr, idkey=None, peerkey=None):
+  """Create/update ID profile"""
   parts = idstr.split(":", 1)
   local = parts[0]
   peer = parts[1] if len(parts) == 2 else ""
   tagself = f"id:{local}"
   for idstore in update(pwhash):
-    if not peer:
-      while True:
-        peer = f".{passphrase.generate(2)}"
-        if f"id:{local}:{peer}" not in idstore:
-          break
+    # If no peer given, create a pseudonymous peername
+    while not peer:
+      peer = f".{passphrase.generate(2)}"
+      if f"id:{local}:{peer}" in idstore: peer = None
     tagpeer = f"id:{local}:{peer}"
-    if tagself not in idstore:
-      idstore[tagself] = dict(I=(idkey or pubkey.Key()).sk)
-    if tagpeer not in idstore:
-      idstore[tagpeer] = dict()
-    if peerkey:
-      idstore[tagpeer]["i"] = peerkey.pk
+    if not (peerkey or tagpeer in idstore):
+      raise ValueError("Peer not in ID store. You need to specify a recipient public key on the first use.")
+    # Add/update records
+    if tagself not in idstore: idstore[tagself] = dict(I=pubkey.Key().sk)
+    if tagpeer not in idstore: idstore[tagpeer] = dict()
+    if idkey: idstore[tagself]["I"] = idkey.sk
+    if peerkey: idstore[tagpeer]["i"] = peerkey.pk
   return pubkey.Key(comment=local, sk=idstore[tagself]["I"]), pubkey.Key(comment=peer, pk=idstore[tagpeer]["i"])
+
+
+def authgen(pwhash):
+  """Try all authentication keys from the keystore"""
+  for idstore in update(pwhash, allow_create=False):
+    try:
+      for key, value in idstore.items():
+        if "I" in value: yield pubkey.Key(comment=key, sk=value["I"])
+    except GeneratorExit:
+      break
 
 # Example
 I = {

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -19,7 +19,6 @@ def create(pwhash, idstore=None):
   a.index["I"] = idstore or {}
   # Encrypt in RAM...
   out = b"".join(b for b in encrypt_file((False, [pwhash], [], []), a.encode, a))
-  fn = idfilename()
   if not confdir.exists():
     confdir.mkdir(parents=True)
     if os.name == "posix":
@@ -27,8 +26,8 @@ def create(pwhash, idstore=None):
       # Attempt to disable CoW (in particular with btrfs and zfs)
       ret = subprocess.run(["chattr", "+C", confdir], capture_output=True)  # nosec
   # Write the ID file
-  with open(fn, "xb") as f:
-    if os.name == "posix": fn.chmod(0o600)
+  with open(idfilename, "xb") as f:
+    if os.name == "posix": idfilename.chmod(0o600)
     f.write(out)
 
 

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -112,7 +112,7 @@ def profile(pwhash, idstr, idkey=None, peerkey=None):
 
 def update_ratchet(pwhash, ratch, a):
   if 'r' in a.index:
-    ratch.prepare_alice(a.filehash, ratch.idkey)
+    ratch.prepare_alice(a.filehash[:32], ratch.idkey)
   for idstore in update(pwhash):
     idstore[ratch.tagpeer]["r"] = ratch.store()
 
@@ -124,7 +124,7 @@ def save_contact(pwhash, idname, a, b):
     idstore[f"id:{idname}"]["i"] = peerkey.pk
     if "r" in a.index:
       r = ratchet.Ratchet()
-      r.init_bob(a.filehash, localkey, peerkey)
+      r.init_bob(a.filehash[:32], localkey, peerkey)
       idstore[f"id:{idname}"]["r"] = r.store()
 
 def authgen(pwhash):
@@ -135,6 +135,7 @@ def authgen(pwhash):
         if "r" in value:
           r = ratchet.Ratchet()
           r.load(value['r'])
+          r.idkey = key
           r.peerkey = pubkey.Key(pk=value['i'])
           try:
             yield r

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from covert import passphrase, pubkey
 from covert.archive import Archive
 from covert.blockstream import decrypt_file, encrypt_file
-from covert.path import create_confdir, idfilename
+from covert.path import create_datadir, idfilename
 
 
 def create(pwhash, idstore=None):
@@ -15,7 +15,7 @@ def create(pwhash, idstore=None):
   a.index["I"] = idstore or {}
   # Encrypt in RAM...
   out = b"".join(b for b in encrypt_file((False, [pwhash], [], []), a.encode, a))
-  create_confdir()
+  create_datadir()
   # Write the ID file
   with open(idfilename, "xb") as f:
     f.write(out)

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -110,6 +110,18 @@ def authgen(pwhash):
     except GeneratorExit:
       break
 
+def idkeys(pwhash):
+  keys = {}
+  for idstore in update(pwhash, allow_create=False):
+    for key, value in idstore.items():
+      if "I" in value:
+        k = pubkey.Key(comment=key, sk=value["I"])
+        keys[k] = k
+      elif "i" in value:
+        k = pubkey.Key(comment=key, pk=value["i"])
+        if k not in keys: keys[k] = k
+  return keys
+
 # Example
 I = {
   "id:alice": {

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -1,0 +1,93 @@
+from covert import passphrase, pubkey
+from covert.blockstream import encrypt_file, decrypt_file
+from covert.archive import Archive
+from pathlib import Path
+import mmap
+import subprocess
+import os
+
+def idfilename():
+  # TODO: Use xdg paths such as ~/.config/covert/idstore on unix systems
+  return Path.home() / ".covert" / "idstore"
+
+def create(pwhash, idstore=None):
+  a = Archive()
+  a.index["I"] = idstore or {}
+  # Encrypt in RAM...
+  out = b"".join(b for b in encrypt_file((False, [pwhash], [], []), a.encode, a))
+  fn = idfilename()
+  confdir = idfilename().parent
+  if not confdir.exists():
+    confdir.mkdir(parents=True)
+    if os.name == "posix":
+      confdir.chmod(0o700)
+      # Attempt to disable CoW (in particular with btrfs and zfs)
+      ret = subprocess.run(["chattr", "+C", confdir], capture_output=True)
+  # Write the ID file
+  with open(fn, "xb") as f:
+    if os.name == "posix": fn.chmod(0o600)
+    f.write(out)
+
+# pwhash = passphrase.pwhash(passphrase.ask("ID Master Passphrase")[0])
+
+def update(pwhash, allow_create=True):
+  fn = idfilename()
+  if allow_create and not fn.exists():
+    idstore = {}
+    yield idstore
+    if idstore: create(pwhash, idstore)
+    return
+  with open(fn, "r+b") as f, mmap.mmap(f.fileno(), 0) as m:
+    # Decrypt everything to RAM
+    a = Archive()
+    for data in a.decode(decrypt_file([pwhash], m, a)):
+      if isinstance(data, dict):
+        if not "I" in data:
+          data["I"] = []
+      elif isinstance(data, bool):
+        if data: a.curfile.data = bytearray()
+      else: a.curfile.data += data
+    try:
+      yield a.index["I"]
+    except StopIteration:
+      pass
+    # Reset archive for re-use in encryption
+    a.reset()
+    a.fds = [BytesIO(f.data) for f in a.flist]
+    a.random_padding(p=0.2)
+    # Encrypt in RAM...
+    out = b"".join(b for b in encrypt_file((False, [pwhash], [], []), a.encode, a))
+    # Overwrite the ID file
+    if len(m) < len(out): m.resize(len(out))
+    m[:len(out)] = out
+    if len(m) > 2.0 * len(out): m.resize(len(m))
+
+def profile(pwhash, idstr, idkey=None, peerkey=None):
+  parts = idstr.split(":", 1)
+  local = parts[0]
+  peer = parts[1] if len(parts) == 2 else ""
+  tagself = f"id:{local}"
+  for idstore in update(pwhash):
+    if not peer:
+      while True:
+        peer = f".{passphrase.generate(2)}"
+        if f"id:{local}:{peer}" not in idstore:
+          break
+    tagpeer = f"id:{local}:{peer}"
+    if tagself not in idstore:
+      idstore[tagself] = dict(I=(idkey or pubkey.Key()).sk)
+    if tagpeer not in idstore:
+      idstore[tagpeer] = dict()
+    if peerkey:
+      idstore[tagpeer]["i"] = peerkey.pk
+  return pubkey.Key(comment=local, sk=idstore[tagself]["I"]), pubkey.Key(comment=peer, pk=idstore[tagpeer]["i"])
+
+# Example
+I = {
+  "id:alice": {
+    "I": bytes(32),
+  },
+  "id:alice:bob": {
+    "i": bytes(32),
+  },
+}

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -10,7 +10,7 @@ from covert.archive import Archive
 from covert.blockstream import decrypt_file, encrypt_file
 
 
-confdir = xdg_config_home() / ".covert"
+confdir = xdg_config_home() / "covert"
 idfilename = confdir / "idstore"
 
 

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -158,21 +158,3 @@ def idkeys(pwhash):
         k = pubkey.Key(comment=key, pk=value["i"])
         if k not in keys: keys[k] = k
   return keys
-
-# Example
-I = {
-  "id:alice": {
-    "I": bytes(32),
-  },
-  "id:alice:bob": {
-    "i": bytes(32),
-    "r": {
-      "pre": [],
-      "msg": [],
-      "DH": bytes(32),
-      "RK": bytes(32),
-      "s": {},
-      "r": {},
-    },
-  },
-}

--- a/covert/passphrase.py
+++ b/covert/passphrase.py
@@ -91,6 +91,7 @@ def autocomplete(pwd, pos):
 
 
 def ask(prompt, create=False):
+  wordcount = 4 if create is True else create
   with fullscreen() as term:
     autohint = ''
     pwd = ''  # nosec
@@ -136,13 +137,13 @@ def ask(prompt, create=False):
         elif ch == "ENTER":
           if valid: return util.encode(pwd), visible
           if create:
-            pwd = generate()
+            pwd = generate(wordcount)
             return util.encode(pwd), True
         elif ch == "ESC":
           visible = not visible
         elif ch == "TAB":
           if create and not pwd:
-            pwd = generate()
+            pwd = generate(wordcount)
             pos = len(pwd)
             visible = True
           else:

--- a/covert/path.py
+++ b/covert/path.py
@@ -1,0 +1,14 @@
+import subprocess
+
+from xdg import xdg_config_home
+
+confdir = xdg_config_home() / "covert"
+idfilename = confdir / "idstore"
+
+def create_confdir():
+  if not confdir.exists():
+    confdir.mkdir(parents=True)
+    if os.name == "posix":
+      confdir.chmod(0o700)
+      # Attempt to disable CoW (in particular with btrfs and zfs)
+      ret = subprocess.run(["chattr", "+C", confdir], capture_output=True)  # nosec

--- a/covert/path.py
+++ b/covert/path.py
@@ -1,15 +1,15 @@
 import os
 import subprocess
 
-from xdg import xdg_config_home
+from xdg import xdg_data_home
 
-confdir = xdg_config_home() / "covert"
-idfilename = confdir / "idstore"
+datadir = xdg_data_home() / "covert"
+idfilename = datadir / "idstore"
 
-def create_confdir():
-  if not confdir.exists():
-    confdir.mkdir(parents=True)
+def create_datadir():
+  if not datadir.exists():
+    datadir.mkdir(parents=True)
     if os.name == "posix":
-      confdir.chmod(0o700)
+      datadir.chmod(0o700)
       # Attempt to disable CoW (in particular with btrfs and zfs)
-      ret = subprocess.run(["chattr", "+C", confdir], capture_output=True)  # nosec
+      ret = subprocess.run(["chattr", "+C", datadir], capture_output=True)  # nosec

--- a/covert/path.py
+++ b/covert/path.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from xdg import xdg_config_home

--- a/covert/ratchet.py
+++ b/covert/ratchet.py
@@ -72,6 +72,9 @@ class Ratchet:
     self.msg = []
     self.pre = []
     self.e = expire_later()
+    # Runtime values, not saved
+    self.peerkey = None
+    self.idkey = None
 
   def store(self):
     return dict(
@@ -88,7 +91,7 @@ class Ratchet:
     self.RK = ratchet['RK']
     self.DH = Key(sk=ratchet['DH']) if ratchet['DH'] else None
     self.s.load(ratchet['s'])
-    self.r.load(ratchet['s'])
+    self.r.load(ratchet['r'])
     self.msg = ratchet['msg']
     self.pre = ratchet['pre']
     self.e = ratchet['e']

--- a/covert/ratchet.py
+++ b/covert/ratchet.py
@@ -22,85 +22,104 @@ class Ratchet:
     self.skipped = []
 
   def init_alice(self, localkey, peerkey):
+    """Prepare Alice for sending initial message(s) to Bob using his public key."""
     self.root = derive_symkey(b"ratchet/init", localkey, peerkey)
+    _, self.nh_recv = chainstep(self.root, b"hkey")
     self.localkey = localkey
     self._tock(peerkey)
 
-  def init_bob(self, localkey, peerkey):
+  def init_bob(self, localkey, ciphertext):
+    """Bob receives an initial message from Alice, initialise ratchet on Bob side for replies."""
+    ephkey = Key(pkhash=ciphertext[:32])
+    key = derive_symkey(ephkey.pkhash[:12], localkey, ephkey)
+    header = decrypt(ciphertext[32:83], None, b"ratchet/init", key)
+    peerkey = Key(pk=header[:32])
+    N = int.from_bytes(header[32:34], "little")
     self.root = derive_symkey(b"ratchet/init", localkey, peerkey)
+    _, self.nh_send = chainstep(self.root, b"hkey")  # Matches Alice's initial nh_recv
     self.localkey = localkey
-    self._tick(peerkey)
+    self.skip_until(N)
+    self.dhstep(peerkey)
+    self.chain_recv, mk = chainstep(self.chain_recv)
+    self.Nr += 1
+    return mk
 
   def dhstep(self, peerkey):
     """ECDH ratchet step, when message with new header key is received."""
     self.PN = self.Ns
     self.Ns = self.Nr = 0
-    self.h_send = self.nh_send
     self.h_recv = self.nh_recv
     self._tick(peerkey)
+    # Right here we should be in sync with the peer.
     self.localkey = Key()
+    self.h_send = self.nh_send
     self._tock(peerkey)
 
   def _tick(self, peerkey):
-    self.root, self.chain_recv = chainstep(self.root, derive_symkey(b"", self.localkey, peerkey))
+    """DH update receiving keys"""
+    self.root, self.chain_recv = chainstep(self.root, derive_symkey(b"ratchet", self.localkey, peerkey))
     _, self.nh_recv = chainstep(self.root, b"hkey")
 
   def _tock(self, peerkey):
-    self.root, self.chain_send = chainstep(self.root, derive_symkey(b"", self.localkey, peerkey))
+    """DH update sending keys"""
+    self.root, self.chain_send = chainstep(self.root, derive_symkey(b"ratchet", self.localkey, peerkey))
     _, self.nh_send = chainstep(self.root, b"hkey")
 
-  def send(self, peerkey):
+  def send(self, peerkey=None):
     f = 1  # Flags: 1 means signature
     if not self.chain_recv:
+      # Alice initial message format
       ephkey = Key()
-      key = derive_symkey(ephkey.pkhash[:12], self.localkey, peerkey)
+      key = derive_symkey(ephkey.pkhash[:12], ephkey, peerkey)
       header = ephkey.pkhash + encrypt(self.localkey.pk + (self.Ns & 0xFFFF).to_bytes(2, "little") + f.to_bytes(1, "little"), None, b"ratchet/init", key)
     else:
+      # Normal ratchet message
       header = encrypt(self.localkey.pk + self.PN.to_bytes(2, "little") + f.to_bytes(1, "little"), None, self.Ns.to_bytes(12, "little"), self.h_send)
     self.chain_send, mk = chainstep(self.chain_send)
     self.Ns += 1
     return header, mk
 
   def receive(self, ciphertext):
-    hkey = self.h_recv
     # Try skipped keys
     for [hkey, n, mk] in self.skipped:
       with suppress(CryptoError):
-        header = decrypt(ciphertext[:35 + 16], None, n.to_bytes(12, "little"), self.h_recv)
+        if hkey:
+          # Normal ratchet messages
+          header = decrypt(ciphertext[:51], None, n.to_bytes(12, "little"), hkey)
+        else:
+          # Alice's initial messages (but Bob is already initialised)
+          ephkey = Key(pkhash=ciphertext[:32])
+          key = derive_symkey(ephkey.pkhash[:12], localkey, ephkey)
+          header = decrypt(ciphertext[32:83], None, b"ratchet/init", key)
         self.skipped.remove([hkey, n, mk])
         return mk
+    header = None
+    # Try with current header key
     if self.h_recv:
-      # Try with old header key
       for n in range(self.Nr, self.Nr + 20):
         with suppress(CryptoError):
-          header = decrypt(ciphertext[:35 + 16], None, n.to_bytes(12, "little"), self.h_recv)
-          self.skip_messages(n)
-    else:
-      # Try with next header key
+          header = decrypt(ciphertext[:51], None, n.to_bytes(12, "little"), self.h_recv)
+          self.skip_until(n)
+          break
+    # Try with next header key
+    if not header:
       for n in range(20):
         with suppress(CryptoError):
-          header = decrypt(ciphertext[:35 + 16], None, n.to_bytes(12, "little"), self.nh_recv)
+          header = decrypt(ciphertext[:51], None, n.to_bytes(12, "little"), self.nh_recv)
           PN = int.from_bytes(header[32:34], "little")
           self.skip_until(PN)
           self.dhstep(Key(pk=header[:32]))
           self.skip_until(n)
+    if not header:
+      raise CryptoError("Unable to authenticate")
+    # Advance receiving chain
     self.chain_recv, mk = chainstep(self.chain_recv)
     self.Nr += 1
     return mk
 
   def skip_until(self, n):
+    """Advance the receiving chain across all messages prior to message n."""
     while self.Nr < n:
       self.chain_recv, mk = chainstep(self.chain_recv)
-      skipped.push([self.h_recv, self.Nr, mk])
+      self.skipped.append([self.h_recv, self.Nr, mk])
       self.Nr += 1
-
-# Header prior to first ratchet reply (Alice's initial messages)
-# nonce = b"ratchet/init"
-# pubkey:   sha(nonce + dh(eph, idB))
-# x3dh:     sha(dh(eph, idB) + dh(eph, skB) [+ dh(eph, otB)])
-# root key = dhstep(idA, skB or idB)
-#[eph:32]{[pk:32][n:2][f:1][nextlen:3]}[tag:16]
-
-# Normal ratchet header
-# nonce = Ns
-#{[dh:32][pn:2][f:1][nextlen:3]}[tag:16]

--- a/covert/ratchet.py
+++ b/covert/ratchet.py
@@ -1,0 +1,106 @@
+import nacl.bindings as sodium
+from nacl.exceptions import CryptoError
+from covert.chacha import encrypt, decrypt
+from covert.pubkey import derive_symkey, Key
+from contextlib import suppress
+
+def chainstep(chainkey: bytes, addn=b""):
+  """Perform a chaining step, returns (new chainkey, message key)."""
+  h = sodium.crypto_hash_sha512(chainkey + addn)
+  return h[:32], h[32:]
+
+
+class Ratchet:
+  def __init__(self):
+    self.root = None
+    self.localkey = None
+    self.chain_send = None
+    self.chain_recv = None
+    self.h_recv = self.h_send = None
+    self.nh_recv = self.nh_send = None
+    self.PN = self.Ns = self.Nr = 0
+    self.skipped = []
+
+  def init_alice(self, localkey, peerkey):
+    self.root = derive_symkey(b"ratchet/init", localkey, peerkey)
+    self.localkey = localkey
+    self._tock(peerkey)
+
+  def init_bob(self, localkey, peerkey):
+    self.root = derive_symkey(b"ratchet/init", localkey, peerkey)
+    self.localkey = localkey
+    self._tick(peerkey)
+
+  def dhstep(self, peerkey):
+    """ECDH ratchet step, when message with new header key is received."""
+    self.PN = self.Ns
+    self.Ns = self.Nr = 0
+    self.h_send = self.nh_send
+    self.h_recv = self.nh_recv
+    self._tick(peerkey)
+    self.localkey = Key()
+    self._tock(peerkey)
+
+  def _tick(self, peerkey):
+    self.root, self.chain_recv = chainstep(self.root, derive_symkey(b"", self.localkey, peerkey))
+    _, self.nh_recv = chainstep(self.root, b"hkey")
+
+  def _tock(self, peerkey):
+    self.root, self.chain_send = chainstep(self.root, derive_symkey(b"", self.localkey, peerkey))
+    _, self.nh_send = chainstep(self.root, b"hkey")
+
+  def send(self, peerkey):
+    f = 1  # Flags: 1 means signature
+    if not self.chain_recv:
+      ephkey = Key()
+      key = derive_symkey(ephkey.pkhash[:12], self.localkey, peerkey)
+      header = ephkey.pkhash + encrypt(self.localkey.pk + (self.Ns & 0xFFFF).to_bytes(2, "little") + f.to_bytes(1, "little"), None, b"ratchet/init", key)
+    else:
+      header = encrypt(self.localkey.pk + self.PN.to_bytes(2, "little") + f.to_bytes(1, "little"), None, self.Ns.to_bytes(12, "little"), self.h_send)
+    self.chain_send, mk = chainstep(self.chain_send)
+    self.Ns += 1
+    return header, mk
+
+  def receive(self, ciphertext):
+    hkey = self.h_recv
+    # Try skipped keys
+    for [hkey, n, mk] in self.skipped:
+      with suppress(CryptoError):
+        header = decrypt(ciphertext[:35 + 16], None, n.to_bytes(12, "little"), self.h_recv)
+        self.skipped.remove([hkey, n, mk])
+        return mk
+    if self.h_recv:
+      # Try with old header key
+      for n in range(self.Nr, self.Nr + 20):
+        with suppress(CryptoError):
+          header = decrypt(ciphertext[:35 + 16], None, n.to_bytes(12, "little"), self.h_recv)
+          self.skip_messages(n)
+    else:
+      # Try with next header key
+      for n in range(20):
+        with suppress(CryptoError):
+          header = decrypt(ciphertext[:35 + 16], None, n.to_bytes(12, "little"), self.nh_recv)
+          PN = int.from_bytes(header[32:34], "little")
+          self.skip_until(PN)
+          self.dhstep(Key(pk=header[:32]))
+          self.skip_until(n)
+    self.chain_recv, mk = chainstep(self.chain_recv)
+    self.Nr += 1
+    return mk
+
+  def skip_until(self, n):
+    while self.Nr < n:
+      self.chain_recv, mk = chainstep(self.chain_recv)
+      skipped.push([self.h_recv, self.Nr, mk])
+      self.Nr += 1
+
+# Header prior to first ratchet reply (Alice's initial messages)
+# nonce = b"ratchet/init"
+# pubkey:   sha(nonce + dh(eph, idB))
+# x3dh:     sha(dh(eph, idB) + dh(eph, skB) [+ dh(eph, otB)])
+# root key = dhstep(idA, skB or idB)
+#[eph:32]{[pk:32][n:2][f:1][nextlen:3]}[tag:16]
+
+# Normal ratchet header
+# nonce = Ns
+#{[dh:32][pn:2][f:1][nextlen:3]}[tag:16]

--- a/covert/tty.py
+++ b/covert/tty.py
@@ -6,6 +6,20 @@ from contextlib import contextmanager
 from shutil import get_terminal_size
 
 
+@contextmanager
+def status(message):
+  """Write a temporary status message that is cleared once processing is complete."""
+  if sys.stderr.isatty():
+    sys.stderr.write(message)
+    sys.stderr.flush()
+    try:
+      yield
+    finally:
+      sys.stderr.write("\r\x1B[0K")
+      sys.stderr.flush()
+  else:
+    yield
+
 def editor(data=""):
   with fullscreen() as term:
     term.write(f'\x1B[1;1H\x1B[1;44m   〰 ENTER MESSAGE 〰   (ESC to finish)\x1B[0K\x1B[0m\n')

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     "msgpack>=1.0",
     "pyperclip>=1.8",
     "zxcvbn-covert>=5.0.1",
+    "xdg>=5.1.1",
   ],
   extras_require={
     "gui": ["pyside6>=6.2.1", "show-in-file-manager>=1.1.2"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,13 +115,13 @@ def test_end_to_end_multiple(covert, tmp_path, mocker):
   )
   assert not cap.out
   assert "foo.txt" in cap.err
-  assert "Key[827bc3b2:EdPK] Signature verified" in cap.err
+  assert "Key[827bc3b2:PK] Signature verified" in cap.err
 
   # Decrypt with passphrase
   cap = covert('dec', '--password', 'verytestysecret', fname)
   assert not cap.out
   assert "foo.txt" in cap.err
-  assert "Key[827bc3b2:EdPK] Signature verified" in cap.err
+  assert "Key[827bc3b2:PK] Signature verified" in cap.err
 
 
 def test_end_to_end_github(covert, tmp_path, mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -404,6 +404,10 @@ def test_errors(covert):
   assert not cap.out
   assert "Unrecognized key not-a-file-either" in cap.err
 
+  cap = covert("enc", "--id", "alice:bob", exitcode=10)
+  assert not cap.out
+  assert "Peer not in ID store. You need to specify a recipient public key on the first use." in cap.err
+
   cap = covert("id", "alice", "bob", exitcode=10)
   assert not cap.out
   assert "one ID at most should be specified" in cap.err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,16 +374,16 @@ def test_ratchet(covert, mocker, tmp_path):
 
 def test_errors(covert):
   cap = covert()
-  assert "Usage:" in cap.out
+  assert "Covert" in cap.out
   assert not cap.err
 
   cap = covert('-eINvalid', '--help')
-  assert "Usage:" in cap.out
+  assert "Covert" in cap.out
   assert not cap.err
 
   cap = covert('-eINvalid', exitcode=1)
   assert not cap.out
-  assert "not an argument: covert enc -INvalid" in cap.err
+  assert "Unknown argument: covert enc -INvalid (failing -N -v -l -d)" in cap.err
 
   cap = covert("-o", exitcode=1)
   assert not cap.out
@@ -465,7 +465,8 @@ def test_miscellaneous(covert, tmp_path, capsys, mocker):
   assert "10,485,761 📄 test.dat" in cap.err
 
   cap = covert("-v")
-  assert "A file and message encryptor with strong anonymity" in cap.out
+  assert "A file and message encryptor" not in cap.out
+  assert "Covert " in cap.out
   assert not cap.err
 
   cap = covert("-e", 1, "-z", exitcode=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,13 +115,13 @@ def test_end_to_end_multiple(covert, tmp_path, mocker):
   )
   assert not cap.out
   assert "foo.txt" in cap.err
-  assert "Key[827bc3b2:PK] Signature verified" in cap.err
+  assert "Signed by Key[827bc3b2:PK]" in cap.err
 
   # Decrypt with passphrase
   cap = covert('dec', '--password', 'verytestysecret', fname)
   assert not cap.out
   assert "foo.txt" in cap.err
-  assert "Key[827bc3b2:PK] Signature verified" in cap.err
+  assert "Signed by Key[827bc3b2:PK]" in cap.err
 
 
 def test_end_to_end_github(covert, tmp_path, mocker):

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -39,6 +39,15 @@ def test_ratchet_pubkey():
   mka2 = a.receive(header2)
   assert mka2 == mkb2
 
+  # Send and receive on current chain (no roundtrip)
+  header4, mkb4 = b.send()
+  header5, mkb5 = b.send()
+  header6, mkb6 = b.send()
+  mka5 = a.receive(header5)
+  assert mka5 == mkb5
+  mka6 = a.receive(header6)
+  assert mka6 == mkb6
+
 
 def test_ratchet_lost_messages():
   alice = Key()

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -7,9 +7,30 @@ def test_ratchet_pubkey():
   a = Ratchet()
   a.init_alice(alice, bob)
   header, mka = a.send(bob)
+  assert len(header) == 83
+  assert mka
+  assert a.Ns == 1
+  assert not a.skipped
+  assert not a.h_send
+  assert a.nh_send
 
   b = Ratchet()
-  b.init_bob(bob, alice)
-  mkb = b.receive(header)
-
+  mkb = b.init_bob(bob, header)
   assert mka == mkb
+  assert b.Nr == 1
+  assert not b.skipped
+  assert b.h_send
+  assert b.h_send == a.nh_recv
+
+  header2, mkb2 = b.send()
+  assert mkb2 != mkb
+
+  header3, mkb3 = b.send()
+  assert mkb3 != mkb2
+
+  # Receive out of order
+  mka3 = a.receive(header3)
+  assert mka3 == mkb3
+
+  mka2 = a.receive(header2)
+  assert mka2 == mkb2

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -1,5 +1,9 @@
-from covert.ratchet import Ratchet
+import pytest
+from nacl.exceptions import CryptoError
+
 from covert.pubkey import Key
+from covert.ratchet import Ratchet
+
 
 def test_ratchet_pubkey():
   alice = Key()
@@ -34,3 +38,42 @@ def test_ratchet_pubkey():
 
   mka2 = a.receive(header2)
   assert mka2 == mkb2
+
+
+def test_ratchet_lost_messages():
+  alice = Key()
+  bob = Key()
+  a = Ratchet()
+  a.init_alice(alice, bob)
+  header0, mka0 = a.send(bob)
+  header1, mka1 = a.send(bob)
+  header2, mka2 = a.send(bob)
+  assert a.Ns == 3
+
+  b = Ratchet()
+  mkb1 = b.init_bob(bob, header1)
+  assert mka1 == mkb1
+  assert b.Nr == 2
+  assert len(b.skipped) == 1
+
+  header3, mkb3 = b.send()
+  header4, mkb4 = b.send()
+  assert b.Ns == 2
+
+  mka4 = a.receive(header4)
+  assert mka4 == mkb4
+  assert a.Nr == 2
+  assert len(a.skipped) == 1
+
+  # Receive out of order
+  mka3 = a.receive(header3)
+  assert mka3 == mkb3
+  assert not a.skipped
+
+  # Receive out of order
+  mkb0 = b.receive(header0)
+  assert mka0 == mkb0
+
+  # Fail to decode own message
+  with pytest.raises(CryptoError):
+    a.receive(header0)

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -1,0 +1,15 @@
+from covert.ratchet import Ratchet
+from covert.pubkey import Key
+
+def test_ratchet_pubkey():
+  alice = Key()
+  bob = Key()
+  a = Ratchet()
+  a.init_alice(alice, bob)
+  header, mka = a.send(bob)
+
+  b = Ratchet()
+  b.init_bob(bob, alice)
+  mkb = b.receive(header)
+
+  assert mka == mkb

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ commands =
 [testenv]
 usedevelop = true
 extras = test
+setenv =
+  HOME = {envtmpdir}
+  XDG_CONFIG_HOME = {envtmpdir}/confhome
 commands =
   coverage run --append -m pytest {posargs:tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,4 @@ commands =
 
 [testenv:security]
 commands =
-  bandit --recursive covert --skip B101
+  bandit --recursive covert --skip B101,B404


### PR DESCRIPTION
Covert needs persistent keystore to avoid always typing keys on command line and more importantly to enable forward secrecy in conversations (because temporary keys need to be stored somewhere).

This is a draft implementation that still contains bugs ~~and does not implement anything but static keys.~~

```fish
covert enc -I alice:bob -i ~/.ssh/id_ed25519 -R github:bob   # Encrypt a message, store keys in database
covert enc -I alice:bob   # Encrypt another message using the stored keys
```

If the sender profile (alice) does not exist, it will be created. If no `-i` is provided, a new keypair is created. Keys may be replaced later by providing another recipient or `-i` arguments. It is planned that bob won't need to add alice's key when replying. In near future this should also enable a conversation mode where replies have forward secrecy and post-breach secrecy. The profile names are strictly local and are never sent to peers.

The ID store is protected by a longer than normal 5-word passphares, which is automatically created the first time the keystore is used. All profiles share the same master passphrase.

Breaking change: Signatures of upcoming 0.7 will be incompatible with prior versions.

TODO:
* [x] Public ID key storage and automatic generation
* [x] Use ID-based keys, display IDs in authentication and signatures instead of raw keys (CLI)
* [x] ID management (key export, changing of passphrase etc) `covert id` subcommand
* [ ] ID selection dropdowns and other functionality based on ID store (GUI)
* [ ] Daemon (agent) that remembers the passphrase for a while
* [ ] Time-based expiration of keys (locally, not planned to be included in messages)
* [x] Code cleanup / refactoring & UX polish
* [ ] Workflow to "reply" to messages in an easy way (CLI, GUI)
* [x] Forward secrecy in conversations
