### PR TITLE
Improve covert dec UX with passphrases and ID store

### DIFF
--- a/covert/cli/dec.py
+++ b/covert/cli/dec.py
@@ -180,7 +180,7 @@ def main_dec(args):
         e = None
         with tty.status("Password hashing... "):
           yield from pwhasher
-          if idstore.idfilename.exists() and not args.askpass:
+          if not args.askpass and idstore.idfilename.exists():
             global idpwhash
             try:
               idpwhash = passphrase.pwhash(passphrase.ask("Master ID passphrase")[0])

--- a/covert/cli/dec.py
+++ b/covert/cli/dec.py
@@ -182,6 +182,7 @@ def main_dec(args):
           yield from pwhasher
           if not args.askpass and idstore.idfilename.exists():
             global idpwhash
+            idpwhash = None  # In case main_dec is run multiple times (happens in tests)
             try:
               idpwhash = passphrase.pwhash(passphrase.ask("Master ID passphrase")[0])
               idkeys = idstore.idkeys(idpwhash)
@@ -189,10 +190,8 @@ def main_dec(args):
             except ValueError as e:
               # Treating as error only when suitable passphrase was given
               if idpwhash: raise ValueError(f"ID store: {e}")
-          # Ask for passphrase by default if no other methods were attempted
-          if not (args.askpass or args.passwords or args.identities):
-            args.askpass = 1
-          for i in range(args.askpass):
+          # Ask for passphrase if asked for or if no other methods were attempted
+          if args.askpass or not (args.passwords or args.identities):
             yield passphrase.pwhash(passphrase.ask('Passphrase')[0])
       if not b.header.key:
         auth = authgen()

--- a/covert/cli/dec.py
+++ b/covert/cli/dec.py
@@ -177,6 +177,7 @@ def main_dec(args):
       def authgen():
         nonlocal idkeys
         yield from identities
+        e = None
         with tty.status("Password hashing... "):
           yield from pwhasher
           if idstore.idfilename.exists() and not args.askpass:
@@ -186,9 +187,10 @@ def main_dec(args):
               idkeys = idstore.idkeys(idpwhash)
               yield from idstore.authgen(idpwhash)
             except ValueError as e:
-              idpwhash = None
+              # Treating as error only when suitable passphrase was given
+              if idpwhash: raise ValueError(f"ID store: {e}")
           # Ask for passphrase by default if no other methods were attempted
-          if not (args.askpass or args.passwords or args.identities or idpwhash):
+          if not (args.askpass or args.passwords or args.identities):
             args.askpass = 1
           for i in range(args.askpass):
             yield passphrase.pwhash(passphrase.ask('Passphrase')[0])


### PR DESCRIPTION
- Fallback to passphrase if no master ID passphrase is given
- Better error message on wrong master ID passphrase or other errors
- Skip ID store if -p is used to indicate passphrase-encrypted message
