### PR TITLE
Second phase of ID store implementation

### DIFF
--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -168,12 +168,15 @@ def remove_expired(ids: dict) -> None:
   t = time.time()
   for k in list(ids):
     v = ids[k]
+    # The entire peer
     if "e" in v and v["e"] < t:
       del ids[k]
       continue
     if "r" in v:
       r = v["r"]
+      # The entire ratchet
       if r["e"] < t:
         del v["r"]
         continue
+      # Message keys
       r["msg"] = [m for m in r['msg'] if m["e"] > t]

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -1,5 +1,6 @@
 import mmap
 import os
+import time
 from contextlib import suppress
 from copy import copy
 from pathlib import Path
@@ -51,6 +52,8 @@ def update(pwhash, allow_create=True, new_pwhash=None):
     # Yield the ID store for operations but do an update even on break/return etc
     with suppress(GeneratorExit):
       yield a.index["I"]
+    # Remove expired records
+    remove_expired(a.index["I"])
     # Reset archive for re-use in encryption
     a.reset()
     a.fds = [BytesIO(f.data) for f in a.flist]
@@ -158,3 +161,19 @@ def idkeys(pwhash):
         k = pubkey.Key(comment=key, pk=value["i"])
         if k not in keys: keys[k] = k
   return keys
+
+
+def remove_expired(ids: dict) -> None:
+  """Delete all records that have expired."""
+  t = time.time()
+  for k in list(ids):
+    v = ids[k]
+    if "e" in v and v["e"] < t:
+      del ids[k]
+      continue
+    if "r" in v:
+      r = v["r"]
+      if r["e"] < t:
+        del v["r"]
+        continue
+      r["msg"] = [m for m in r['msg'] if m["e"] > t]

--- a/covert/ratchet.py
+++ b/covert/ratchet.py
@@ -1,6 +1,6 @@
 import itertools
 from contextlib import suppress
-from time import time
+import time
 
 import nacl.bindings as sodium
 from nacl.exceptions import CryptoError
@@ -11,10 +11,10 @@ from covert.pubkey import Key, derive_symkey
 MAXSKIP = 20
 
 def expire_soon():
-  return int(time()) + 600  # 10 minutes
+  return int(time.time()) + 600  # 10 minutes
 
 def expire_later():
-  return int(time()) + 86400 * 28  # four weeks
+  return int(time.time()) + 86400 * 28  # four weeks
 
 def chainstep(chainkey: bytes, addn=b""):
   """Perform a chaining step, returns (new chainkey, message key)."""


### PR DESCRIPTION
Continuation of the work in #81.

TODO:
* [x] Public ID key storage and automatic generation
* [x] Use ID-based keys, display IDs in authentication and signatures instead of raw keys (CLI)
* [x] ID management (key export, changing of passphrase etc) `covert id` subcommand
* [ ] ID selection dropdowns and other functionality based on ID store (GUI)
* [ ] Daemon (agent) that remembers the passphrase for a while
* [x] Time-based expiration of keys (locally, not planned to be included in messages)
* [x] Code cleanup / refactoring & UX polish
* [ ] Workflow to "reply" to messages in an easy way (CLI, GUI)
* [x] Forward secrecy in conversations
