### PR TITLE
Fix handling of weak password input in TTY

### DIFF
--- a/covert/passphrase.py
+++ b/covert/passphrase.py
@@ -138,7 +138,7 @@ def ask(prompt, create=False):
         elif ch == 'END': pos = len(pwd)
         elif ch == "ENTER":
           if valid: return util.encode(pwd), visible
-          if create:
+          if not pwd and create:
             pwd = generate(wordcount)
             return util.encode(pwd), True
         elif ch == "ESC":


### PR DESCRIPTION
Covert would generate a passphrase if a very weak password was input, dismissing the bad password, which was confusing. Now the prompt only accepts either an empty input or a valid password.