### PR TITLE
Quick fix to GUI not being able to open files.

### DIFF
--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -37,6 +37,7 @@ class BlockStream:
     self.nonce = None
     self.workers = 8
     self.executor = ThreadPoolExecutor(max_workers=self.workers)
+    self.header = None
     self.blkhash = None
     self.file = None
     self.ciphertext = None

--- a/covert/gui/decrypt.py
+++ b/covert/gui/decrypt.py
@@ -15,8 +15,8 @@ class DecryptView(QWidget):
   def __init__(self, app, infile):
     QWidget.__init__(self)
     self.blockstream = BlockStream()
-    self.blockstream.decrypt_init(infile)
-
+    self.decrypt_ctx = self.blockstream.decrypt_init(infile)
+    self.decrypt_ctx.__enter__()
     self.setMinimumWidth(535)
     self.app = app
     self.init_keyinput()


### PR DESCRIPTION
The GUI was not updated properly for 0.7 release and is not up to date with CLI. This PR patches one of the issues, allowing basic GUI use until it can be properly synced with CLI functionality.

Notably missing are idstore and forward secrecy functionality.